### PR TITLE
[IMP] base_tier_validation_forward: allow user to select backward

### DIFF
--- a/base_tier_validation_forward/models/tier_validation.py
+++ b/base_tier_validation_forward/models/tier_validation.py
@@ -6,17 +6,20 @@ from odoo import _, api, fields, models
 class TierValidation(models.AbstractModel):
     _inherit = "tier.validation"
 
-    can_forward = fields.Boolean(compute="_compute_can_forward")
+    can_forward = fields.Boolean(compute="_compute_forward_backward")
+    can_backward = fields.Boolean(compute="_compute_forward_backward")
 
-    def _compute_can_forward(self):
+    def _compute_forward_backward(self):
         for rec in self:
             if not rec.can_review:
                 rec.can_forward = False
+                rec.can_backward = False
                 continue
             sequences = self._get_sequences_to_approve(self.env.user)
             reviews = rec.review_ids.filtered(lambda l: l.sequence in sequences)
             definitions = reviews.mapped("definition_id")
             rec.can_forward = True in definitions.mapped("has_forward")
+            rec.can_backward = True in definitions.mapped("backward")
 
     @api.model
     def _calc_reviews_validated(self, reviews):

--- a/base_tier_validation_forward/readme/CONTRIBUTORS.rst
+++ b/base_tier_validation_forward/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Kitti U. <kittiu@ecosoft.co.th>
+* Adria Gil Sorribes <adria.gil@forgeflow.com>

--- a/base_tier_validation_forward/readme/DESCRIPTION.rst
+++ b/base_tier_validation_forward/readme/DESCRIPTION.rst
@@ -9,3 +9,7 @@ for some reason, and want to pass/forward the decision to another person.
 
 User can then click on Forward instead of Approve. A new tier with minor sequence will be
 created on the reviewer table, and new user will be able to make approval decision.
+
+User has also the ability to ask for someone to review the tier before making
+the final decision, he/she forwards it to another user, after that user has
+validated the tier, the decision is back to the original user.

--- a/base_tier_validation_forward/tests/test_tier_validation.py
+++ b/base_tier_validation_forward/tests/test_tier_validation.py
@@ -118,3 +118,71 @@ class TierTierValidation(SavepointCase):
         wiz = wizard.save()
         wiz.add_comment()
         self.assertTrue(record.validated)
+
+    def test_02_forward_tier_backward(self):
+        # Create new test record
+        test_record = self.test_model.create({"test_field": 2.5})
+        # Create tier definitions
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_2.id,
+                "definition_domain": "[('test_field', '>', 1.0)]",
+                "approve_sequence": True,
+                "has_forward": True,
+                "backward": True,
+            }
+        )
+        # Request validation
+        review = test_record.with_user(self.test_user_2.id).request_validation()
+        self.assertTrue(review)
+        record = test_record.with_user(self.test_user_1.id)
+        record.invalidate_cache()
+        record.validate_tier()
+        self.assertFalse(record.can_forward)
+        self.assertFalse(record.can_backward)
+        # User 2 forward to user 1
+        record = test_record.with_user(self.test_user_2.id)
+        record.invalidate_cache()
+        self.assertTrue(record.can_forward)
+        self.assertTrue(record.can_backward)
+        res = record.forward_tier()
+        ctx = res.get("context")
+        wizard = Form(
+            self.env["tier.validation.forward.wizard"]
+            .with_user(self.test_user_2.id)
+            .with_context(ctx)
+        )
+        wizard.forward_reviewer_id = self.test_user_1
+        wizard.forward_description = "Please review again"
+        wizard.backward = True
+        wiz = wizard.save()
+        wiz.add_forward()
+        # Newly created forwarded review will have no definition and will have origin
+        record = test_record.with_user(self.test_user_2.id)
+        record.invalidate_cache()
+        self.assertTrue(record.review_ids.filtered(lambda l: not l.definition_id))
+        self.assertTrue(record.review_ids.filtered(lambda l: l.origin_id))
+        # User 1 validate
+        res = record.with_user(self.test_user_1.id).validate_tier()
+        ctx = res.get("context")
+        wizard = Form(
+            self.env["comment.wizard"].with_user(self.test_user_1.id).with_context(ctx)
+        )
+        wizard.comment = "Forward tier is reviewed"
+        wiz = wizard.save()
+        wiz.add_comment()
+        self.assertFalse(record.validated)
+        # Newly created review back to the original user
+        record = test_record.with_user(self.test_user_2.id)
+        record.invalidate_cache()
+        # There are now two tier reviews for user 2
+        self.assertEqual(
+            len(record.review_ids.filtered(
+                lambda l: l.reviewer_id == self.test_user_2)),
+            2
+        )
+        # User 2 does final validation
+        record.validate_tier()
+        self.assertTrue(record.validated)

--- a/base_tier_validation_forward/views/tier_definition_view.xml
+++ b/base_tier_validation_forward/views/tier_definition_view.xml
@@ -20,7 +20,7 @@
                     title="If the forwarded step is approved, auto forward back again to finish the step."
                 >
                     <field name="backward" />
-                    <span>Auto backward after the forward step is validated</span>
+                    <span>Allow backward after the forward step is validated</span>
                 </div>
             </field>
         </field>

--- a/base_tier_validation_forward/wizard/forward_wizard.py
+++ b/base_tier_validation_forward/wizard/forward_wizard.py
@@ -20,6 +20,32 @@ class ValidationForwardWizard(models.TransientModel):
         string="Approve by sequence",
         default=True,
     )
+    can_backward = fields.Boolean(
+        string="Can ask for review",
+        compute="_compute_can_backward"
+    )
+    backward = fields.Boolean(
+        string="Ask for review",
+        default=False
+    )
+
+    def _compute_can_backward(self):
+        self.ensure_one()
+        record = self.env[self.res_model].browse(self.res_id)
+        self.can_backward = record.can_backward
+
+    def _get_tier_review_data(self, rec, prev_review):
+        data = {
+            "model": rec._name,
+            "res_id": rec.id,
+            "sequence": round(prev_review.sequence + 0.1, 2),
+            "requested_by": self.env.uid,
+        }
+        if self.backward:
+            data.update({
+                "origin_id": prev_review.id,
+            })
+        return data
 
     def add_forward(self):
         """ Add extra step, with specific reviewer """
@@ -34,13 +60,7 @@ class ValidationForwardWizard(models.TransientModel):
         prev_reviews = prev_comment.add_comment()
         prev_review = prev_reviews.sorted("sequence")[-1:]  # Get max sequence
         review = self.env["tier.review"].create(
-            {
-                "model": rec._name,
-                "res_id": rec.id,
-                "sequence": round(prev_review.sequence + 0.1, 2),
-                "requested_by": self.env.uid,
-                "origin_id": prev_review.id,
-            }
+            self._get_tier_review_data(rec, prev_review)
         )
         # Because following fileds are readonly, we need to write after create
         review.write(

--- a/base_tier_validation_forward/wizard/forward_wizard_view.xml
+++ b/base_tier_validation_forward/wizard/forward_wizard_view.xml
@@ -12,9 +12,11 @@
                     <group>
                         <field name="forward_reviewer_id" />
                         <field name="forward_description" required="1" />
+                        <field name="backward" />
                     </group>
                     <group>
                         <field name="has_comment" invisible="1" />
+                        <field name="can_backward" invisible="1" />
                         <field name="approve_sequence" invisible="1" />
                     </group>
                 </group>


### PR DESCRIPTION
As mentioned here: https://github.com/OCA/server-ux/pull/272 I'm proposing a way so the user can be the one deciding if the final decision should be made by another person or just ask someone to review it.

Let me know what you think.