### PR TITLE
[18.0][FIX] base_cancel_confirm: fix KeyError arch in unit test

### DIFF
--- a/base_cancel_confirm/__manifest__.py
+++ b/base_cancel_confirm/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Base Cancel Confirm",
-    "version": "16.0.1.0.1",
+    "version": "18.0.1.0.0",
     "author": "Ecosoft,Odoo Community Association (OCA)",
     "category": "Usability",
     "license": "AGPL-3",

--- a/base_cancel_confirm/model/base_cancel_confirm.py
+++ b/base_cancel_confirm/model/base_cancel_confirm.py
@@ -28,7 +28,7 @@ class BaseCancelConfirm(models.AbstractModel):
     )
 
     def _cancel_confirm_disabled(self):
-        key = "%s.cancel_confirm_disable" % self._name
+        key = f"{self._name}.cancel_confirm_disable"
         res = self.env["ir.config_parameter"].sudo().get_param(key)
         if not res:
             return True

--- a/base_cancel_confirm/tests/test_cancel_confirm.py
+++ b/base_cancel_confirm/tests/test_cancel_confirm.py
@@ -3,9 +3,10 @@
 from lxml import etree
 from odoo_test_helper import FakeModelLoader
 
-from odoo.tests import Form, common
+from odoo.tests import Form, common, tagged
 
 
+@tagged("post_install", "-at_install")
 class TestCancelConfirm(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
@@ -99,7 +100,7 @@ class TestCancelConfirm(common.TransactionCase):
             </form>""",
             }
         )
-        with Form(self.test_record) as f:
-            form = etree.fromstring(f._view["arch"])
-            self.assertTrue(form.xpath("//field[@name='cancel_confirm']"))
-            self.assertTrue(form.xpath("//field[@name='cancel_reason']"))
+        view = self.env[self.test_record._name].get_view(False, "form")
+        form = etree.fromstring(view["arch"])
+        self.assertTrue(form.xpath("//field[@name='cancel_confirm']"))
+        self.assertTrue(form.xpath("//field[@name='cancel_reason']"))

--- a/base_cancel_confirm/wizard/cancel_confirm.xml
+++ b/base_cancel_confirm/wizard/cancel_confirm.xml
@@ -10,8 +10,8 @@
                     <field name="has_cancel_reason" invisible="1" />
                     <field
                         name="cancel_reason"
-                        attrs="{'invisible': [('has_cancel_reason', '=', 'no')],
-                                                        'required': [('has_cancel_reason', '=', 'required')]}"
+                        invisible="has_cancel_reason == 'no'"
+                        required="has_cancel_reason == 'required'"
                     />
                 </group>
                 <footer>


### PR DESCRIPTION
This PR was created to fix the KeyError 'arch' in the unit test.